### PR TITLE
Fix: create fake directories for resources & more

### DIFF
--- a/irods/ires-hnas/hooks/bootstrap_pre_hook.sh
+++ b/irods/ires-hnas/hooks/bootstrap_pre_hook.sh
@@ -7,13 +7,19 @@ echo "INFO: This patch will mkresc if the resource is not already registered and
 patch_setup_irods /opt/irods/patch/setup_irods_already_installed_dev.patch
 
 # Create fake HNAS (nothing real is volume mapped in development)
-if [[ ! -d "/mnt/${ENV_IRODS_STOR_RESC_NAME}" ]]; then
-    mkdir -p "/mnt/${ENV_IRODS_STOR_RESC_NAME}"
-    chown irods:irods "/mnt/${ENV_IRODS_STOR_RESC_NAME}"
-    mkdir -p "/mnt/${ENV_IRODS_STOR_RESC_NAME}-repl"
-    chown irods:irods "/mnt/${ENV_IRODS_STOR_RESC_NAME}-repl"
-    echo "INFO: Creating fake physical resource for HNAS at /mnt/${ENV_IRODS_STOR_RESC_NAME}"
-else
-    echo "INFO: HNAS physical resource at /mnt/${ENV_IRODS_STOR_RESC_NAME} already exists."
-fi
+echo "INFO: Creating fake physical resource for HNAS at /mnt/${ENV_IRODS_STOR_RESC_NAME} and /mnt/${ENV_IRODS_STOR_RESC_NAME}-repl"
+mkdir -p "/mnt/${ENV_IRODS_STOR_RESC_NAME}"
+chown irods:irods "/mnt/${ENV_IRODS_STOR_RESC_NAME}"
+mkdir -p "/mnt/${ENV_IRODS_STOR_RESC_NAME}-repl"
+chown irods:irods "/mnt/${ENV_IRODS_STOR_RESC_NAME}-repl"
 
+echo "INFO: mocking irods-pre-ingest mount"
+# Create the pre-ingest directory
+mkdir -p /var/log/irods-pre-ingest
+chown irods:irods /var/log/irods-pre-ingest
+
+echo "INFO: mocking ingest zones: /mnt/ingest/zones (mounted), and /mnt/stagingResc01 (direct)"
+mkdir -p /mnt/ingest/zones
+mkdir -p /mnt/stagingResc01
+chown irods:irods /mnt/ingest/zones
+chown irods:irods /mnt/stagingResc01


### PR DESCRIPTION
dh-irods/hnas expects these directories to exist. Either they are volume mapped to real storage volumes, or we fake that in the pre_hook